### PR TITLE
perf: Remove empty documents at tdm

### DIFF
--- a/fake-news.R
+++ b/fake-news.R
@@ -31,6 +31,11 @@ corpus<-tm_map(corpus, stemDocument)
 
 # Compute TF-IDF
 tdm<-TermDocumentMatrix(corpus)
+
+if (any(apply(tdm, 2, sum) == 0)) {
+  tdm <- tdm[, apply(tdm, 2, sum) != 0]
+}
+
 tridf<-weightTfIdf(tdm)
 
 # Extract (20) concepts


### PR DESCRIPTION
Co-authored-by: ImKunYoung <ur2kunyoung2@outlook.com>

## Description

Removed empty documents at tdm using following code:

```r
if (any(apply(tdm, 2, sum) == 0)) {
  tdm <- tdm[, apply(tdm, 2, sum) != 0]
}
```